### PR TITLE
Updating the version of the ARM cross compiler

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /usr/local/arm-cross-compiler/
 
 # Assignment 3 - ARM cross compiler
 RUN wget -O gcc-arm.tar.xz \
-    https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz && \
+    https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-linux-gnu.tar.xz && \
     mkdir install && \
     tar x -C install -f gcc-arm.tar.xz && \
     rm -r gcc-arm.tar.xz


### PR DESCRIPTION
Based on ticket [Issue](https://github.com/orgs/cu-ecen-aeld/projects/23/views/1?pane=issue&itemId=51698928)

Tested locally with `docker run -v $(pwd):$(pwd) -it cuaesd/aesd-autotest:assignment3`

And ran the full-test.sh for A3 

<img width="790" alt="image" src="https://github.com/cu-ecen-aeld/aesd-autotest-docker/assets/134313353/c247a349-1eaf-4252-b1f1-a8d37f05d655">
